### PR TITLE
Add placeholder pages for missing sidebar routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,16 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { MainLayout } from "./components/layout/MainLayout"
 import { Dashboard } from "./pages/Dashboard"
 import { StockOnhand } from "./pages/StockOnhand"
+import { GoodsReceipt } from "./pages/GoodsReceipt"
+import { CreateGoodsReceipt } from "./pages/CreateGoodsReceipt"
+import { GoodsReceiptDetail } from "./pages/GoodsReceiptDetail"
+import { GoodsIssue } from "./pages/GoodsIssue"
+import { InventoryCount } from "./pages/InventoryCount"
+import { GoodsTransfer } from "./pages/GoodsTransfer"
+import { Putaway } from "./pages/Putaway"
 import { UoM } from "./pages/UoM"
 import { Partner } from "./pages/Partner"
 import { Organization } from "./pages/Organization"
@@ -12,9 +19,8 @@ import { Warehouse } from "./pages/Warehouse"
 import { Location } from "./pages/Location"
 import { GoodsType } from "./pages/GoodsType"
 import { ModelGoods } from "./pages/ModelGoods"
-import { GoodsReceipt } from "./pages/GoodsReceipt"
-import { CreateGoodsReceipt } from "./pages/CreateGoodsReceipt"
-import { GoodsReceiptDetail } from "./pages/GoodsReceiptDetail"
+import { Reports } from "./pages/Reports"
+import { Authentication } from "./pages/Authentication"
 
 type PageType =
   | "dashboard"
@@ -22,6 +28,10 @@ type PageType =
   | "goods-receipt"
   | "create-goods-receipt"
   | "goods-receipt-detail"
+  | "goods-issue"
+  | "inventory-count"
+  | "goods-transfer"
+  | "putaway"
   | "uom"
   | "partner"
   | "organization"
@@ -30,106 +40,188 @@ type PageType =
   | "location"
   | "goods-type"
   | "model-goods"
+  | "reports"
+  | "authentication"
+
+type Breadcrumb = { label: string; href?: string }
+
+const HASH_TO_PAGE: Record<string, PageType> = {
+  dashboard: "dashboard",
+  "stock-onhand": "stock-onhand",
+  "goods-receipt": "goods-receipt",
+  "create-goods-receipt": "create-goods-receipt",
+  "goods-receipt-detail": "goods-receipt-detail",
+  "goods-issue": "goods-issue",
+  "inventory-count": "inventory-count",
+  "goods-transfer": "goods-transfer",
+  putaway: "putaway",
+  uom: "uom",
+  partner: "partner",
+  organization: "organization",
+  branch: "branch",
+  warehouse: "warehouse",
+  location: "location",
+  "goods-type": "goods-type",
+  "model-goods": "model-goods",
+  reports: "reports",
+  authentication: "authentication",
+}
+
+const BREADCRUMBS: Record<PageType, Breadcrumb[]> = {
+  dashboard: [{ label: "Dashboard" }],
+  "stock-onhand": [
+    { label: "Home", href: "#dashboard" },
+    { label: "Warehouse Operations" },
+    { label: "Stock Onhand" },
+  ],
+  "goods-receipt": [
+    { label: "Home", href: "#dashboard" },
+    { label: "Warehouse Operations" },
+    { label: "Goods Receipt" },
+  ],
+  "create-goods-receipt": [
+    { label: "Home", href: "#dashboard" },
+    { label: "Warehouse Operations" },
+    { label: "Goods Receipt", href: "#goods-receipt" },
+    { label: "Create" },
+  ],
+  "goods-receipt-detail": [
+    { label: "Home", href: "#dashboard" },
+    { label: "Warehouse Operations" },
+    { label: "Goods Receipt", href: "#goods-receipt" },
+    { label: "Goods Receipt Details" },
+  ],
+  "goods-issue": [
+    { label: "Home", href: "#dashboard" },
+    { label: "Warehouse Operations" },
+    { label: "Goods Issue" },
+  ],
+  "inventory-count": [
+    { label: "Home", href: "#dashboard" },
+    { label: "Warehouse Operations" },
+    { label: "Inventory Count" },
+  ],
+  "goods-transfer": [
+    { label: "Home", href: "#dashboard" },
+    { label: "Warehouse Operations" },
+    { label: "Goods Transfer" },
+  ],
+  putaway: [
+    { label: "Home", href: "#dashboard" },
+    { label: "Warehouse Operations" },
+    { label: "Putaway" },
+  ],
+  uom: [
+    { label: "Home", href: "#dashboard" },
+    { label: "Master Data" },
+    { label: "UoM" },
+  ],
+  partner: [
+    { label: "Home", href: "#dashboard" },
+    { label: "Master Data" },
+    { label: "Partner" },
+  ],
+  organization: [
+    { label: "Home", href: "#dashboard" },
+    { label: "Master Data" },
+    { label: "Organization" },
+  ],
+  branch: [
+    { label: "Home", href: "#dashboard" },
+    { label: "Master Data" },
+    { label: "Branch" },
+  ],
+  warehouse: [
+    { label: "Home", href: "#dashboard" },
+    { label: "Master Data" },
+    { label: "Warehouse" },
+  ],
+  location: [
+    { label: "Home", href: "#dashboard" },
+    { label: "Master Data" },
+    { label: "Location" },
+  ],
+  "goods-type": [
+    { label: "Home", href: "#dashboard" },
+    { label: "Goods Management" },
+    { label: "Goods Type" },
+  ],
+  "model-goods": [
+    { label: "Home", href: "#dashboard" },
+    { label: "Goods Management" },
+    { label: "Model Goods" },
+  ],
+  reports: [
+    { label: "Home", href: "#dashboard" },
+    { label: "Reports" },
+  ],
+  authentication: [
+    { label: "Home", href: "#dashboard" },
+    { label: "Authentication" },
+  ],
+}
 
 export default function App() {
   const [currentPage, setCurrentPage] = useState<PageType>("dashboard")
 
-  // Listen to hash changes for navigation
   useEffect(() => {
     const handleHashChange = () => {
       const hash = window.location.hash.slice(1)
-      if (hash === "stock-onhand") {
-        setCurrentPage("stock-onhand")
-      } else if (hash === "goods-receipt") {
-        setCurrentPage("goods-receipt")
-      } else if (hash === "create-goods-receipt") {
-        setCurrentPage("create-goods-receipt")
-      } else if (hash === "goods-receipt-detail") {
-        setCurrentPage("goods-receipt-detail")
-      } else if (hash === "uom") {
-        setCurrentPage("uom")
-      } else if (hash === "partner") {
-        setCurrentPage("partner")
-      } else if (hash === "organization") {
-        setCurrentPage("organization")
-      } else if (hash === "branch") {
-        setCurrentPage("branch")
-      } else if (hash === "warehouse") {
-        setCurrentPage("warehouse")
-      } else if (hash === "location") {
-        setCurrentPage("location")
-      } else if (hash === "goods-type") {
-        setCurrentPage("goods-type")
-      } else if (hash === "model-goods") {
-        setCurrentPage("model-goods")
-      } else {
-        setCurrentPage("dashboard")
-      }
+      setCurrentPage(HASH_TO_PAGE[hash] ?? "dashboard")
     }
 
-    // Set initial page based on hash
     handleHashChange()
 
     window.addEventListener("hashchange", handleHashChange)
     return () => window.removeEventListener("hashchange", handleHashChange)
   }, [])
 
-  const getBreadcrumbs = () => {
+  const breadcrumbs = useMemo(() => BREADCRUMBS[currentPage] ?? BREADCRUMBS.dashboard, [currentPage])
+
+  const renderPage = () => {
     switch (currentPage) {
+      case "dashboard":
+        return <Dashboard />
       case "stock-onhand":
-        return [{ label: "Home", href: "#dashboard" }, { label: "Warehouse Operations" }, { label: "Stock Onhand" }]
+        return <StockOnhand />
       case "goods-receipt":
-        return [{ label: "Home", href: "#dashboard" }, { label: "Warehouse Operations" }, { label: "Goods Receipt" }]
+        return <GoodsReceipt />
       case "create-goods-receipt":
-        return [
-          { label: "Home", href: "#dashboard" },
-          { label: "Warehouse Operations" },
-          { label: "Goods Receipt", href: "#goods-receipt" },
-          { label: "Create" },
-        ]
+        return <CreateGoodsReceipt />
       case "goods-receipt-detail":
-        return [
-          { label: "Home", href: "#dashboard" },
-          { label: "Warehouse Operations" },
-          { label: "Goods Receipt", href: "#goods-receipt" },
-          { label: "Goods Receipt Details" },
-        ]
+        return <GoodsReceiptDetail />
+      case "goods-issue":
+        return <GoodsIssue />
+      case "inventory-count":
+        return <InventoryCount />
+      case "goods-transfer":
+        return <GoodsTransfer />
+      case "putaway":
+        return <Putaway />
       case "uom":
-        return [{ label: "Home", href: "#dashboard" }, { label: "Master Data" }, { label: "UoM" }]
+        return <UoM />
       case "partner":
-        return [{ label: "Home", href: "#dashboard" }, { label: "Master Data" }, { label: "Partner" }]
+        return <Partner />
       case "organization":
-        return [{ label: "Home", href: "#dashboard" }, { label: "Master Data" }, { label: "Organization" }]
+        return <Organization />
       case "branch":
-        return [{ label: "Home", href: "#dashboard" }, { label: "Master Data" }, { label: "Branch" }]
+        return <Branch />
       case "warehouse":
-        return [{ label: "Home", href: "#dashboard" }, { label: "Master Data" }, { label: "Warehouse" }]
+        return <Warehouse />
       case "location":
-        return [{ label: "Home", href: "#dashboard" }, { label: "Master Data" }, { label: "Location" }]
+        return <Location />
       case "goods-type":
-        return [{ label: "Home", href: "#dashboard" }, { label: "Goods Management" }, { label: "Goods Type" }]
+        return <GoodsType />
       case "model-goods":
-        return [{ label: "Home", href: "#dashboard" }, { label: "Goods Management" }, { label: "Model Goods" }]
+        return <ModelGoods />
+      case "reports":
+        return <Reports />
+      case "authentication":
+        return <Authentication />
       default:
-        return [{ label: "Dashboard" }]
+        return <Dashboard />
     }
   }
 
-  return (
-    <MainLayout breadcrumbs={getBreadcrumbs()}>
-      {currentPage === "dashboard" && <Dashboard />}
-      {currentPage === "stock-onhand" && <StockOnhand />}
-      {currentPage === "goods-receipt" && <GoodsReceipt />}
-      {currentPage === "create-goods-receipt" && <CreateGoodsReceipt />}
-      {currentPage === "goods-receipt-detail" && <GoodsReceiptDetail />}
-      {currentPage === "uom" && <UoM />}
-      {currentPage === "partner" && <Partner />}
-      {currentPage === "organization" && <Organization />}
-      {currentPage === "branch" && <Branch />}
-      {currentPage === "warehouse" && <Warehouse />}
-      {currentPage === "location" && <Location />}
-      {currentPage === "goods-type" && <GoodsType />}
-      {currentPage === "model-goods" && <ModelGoods />}
-    </MainLayout>
-  )
+  return <MainLayout breadcrumbs={breadcrumbs}>{renderPage()}</MainLayout>
 }

--- a/src/pages/Authentication.tsx
+++ b/src/pages/Authentication.tsx
@@ -1,0 +1,47 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card';
+import { Separator } from '../components/ui/separator';
+import { useLanguage } from '../contexts/LanguageContext';
+
+export function Authentication() {
+  const { t } = useLanguage();
+
+  const roadmapItems = [
+    'Single sign-on with corporate identity provider',
+    'Multi-factor authentication with configurable factors',
+    'Session audit logs and anomaly detection alerts',
+  ];
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>{t('authentication')}</CardTitle>
+          <CardDescription>Configure sign-in policies and monitor user access activity.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <section>
+            <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">Roadmap</h3>
+            <Separator className="my-3" />
+            <ul className="space-y-2 text-sm text-muted-foreground">
+              {roadmapItems.map((item) => (
+                <li key={item} className="flex items-start gap-2">
+                  <span className="mt-1 h-1.5 w-1.5 rounded-full bg-primary" aria-hidden />
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <section>
+            <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">Next actions</h3>
+            <Separator className="my-3" />
+            <p className="text-sm text-muted-foreground">
+              Connect this module to your identity platform to enable policy enforcement. Until then, use administrative tools
+              to manage user provisioning manually.
+            </p>
+          </section>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/pages/GoodsIssue.tsx
+++ b/src/pages/GoodsIssue.tsx
@@ -1,0 +1,53 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card';
+import { Separator } from '../components/ui/separator';
+import { useLanguage } from '../contexts/LanguageContext';
+
+export function GoodsIssue() {
+  const { t } = useLanguage();
+
+  const reminders = [
+    'Verify pick list quantities before issuing stock.',
+    'Capture carrier and tracking references for each delivery.',
+    'Confirm that all quality holds are released before shipment.',
+  ];
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>{t('goods_issue')}</CardTitle>
+          <CardDescription>
+            Manage outbound stock movements, confirm deliveries, and capture proof of shipment.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <section>
+            <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">
+              Process overview
+            </h3>
+            <Separator className="my-3" />
+            <p className="text-sm text-muted-foreground">
+              Use this workspace to validate picking requests, prepare shipping documents, and post goods issues to update on-hand
+              balances. Workflow automation and integrations can be configured in future iterations.
+            </p>
+          </section>
+
+          <section>
+            <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">
+              Daily reminders
+            </h3>
+            <Separator className="my-3" />
+            <ul className="space-y-2 text-sm text-muted-foreground">
+              {reminders.map((item) => (
+                <li key={item} className="flex items-start gap-2">
+                  <span className="mt-1 h-1.5 w-1.5 rounded-full bg-primary" aria-hidden />
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+          </section>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/pages/GoodsTransfer.tsx
+++ b/src/pages/GoodsTransfer.tsx
@@ -1,0 +1,49 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card';
+import { Separator } from '../components/ui/separator';
+import { useLanguage } from '../contexts/LanguageContext';
+
+export function GoodsTransfer() {
+  const { t } = useLanguage();
+
+  const workflowSteps = [
+    'Select the source warehouse and staging location.',
+    'Choose the destination site and confirm transport mode.',
+    'Review quantities, packaging, and special handling notes.',
+  ];
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>{t('goods_transfer')}</CardTitle>
+          <CardDescription>
+            Coordinate inter-warehouse movements and ensure stock arrives accurately and on time.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <section>
+            <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">Transfer workflow</h3>
+            <Separator className="my-3" />
+            <ul className="space-y-2 text-sm text-muted-foreground">
+              {workflowSteps.map((item) => (
+                <li key={item} className="flex items-start gap-2">
+                  <span className="mt-1 h-1.5 w-1.5 rounded-full bg-primary" aria-hidden />
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <section>
+            <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">Next steps</h3>
+            <Separator className="my-3" />
+            <p className="text-sm text-muted-foreground">
+              Detailed transfer orders, approval routing, and shipment tracking will be integrated here. For now, document transfer
+              details offline and reconcile balances after arrival.
+            </p>
+          </section>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/pages/InventoryCount.tsx
+++ b/src/pages/InventoryCount.tsx
@@ -1,0 +1,49 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card';
+import { Separator } from '../components/ui/separator';
+import { useLanguage } from '../contexts/LanguageContext';
+
+export function InventoryCount() {
+  const { t } = useLanguage();
+
+  const preparationSteps = [
+    'Generate cycle count tasks and notify assigned users.',
+    'Print bin and product labels for manual verification.',
+    'Lock locations or items that require recounts until approval.',
+  ];
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>{t('inventory_count')}</CardTitle>
+          <CardDescription>
+            Plan, execute, and reconcile physical stock counts with system balances.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <section>
+            <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">Preparation checklist</h3>
+            <Separator className="my-3" />
+            <ul className="space-y-2 text-sm text-muted-foreground">
+              {preparationSteps.map((item) => (
+                <li key={item} className="flex items-start gap-2">
+                  <span className="mt-1 h-1.5 w-1.5 rounded-full bg-primary" aria-hidden />
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <section>
+            <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">Status</h3>
+            <Separator className="my-3" />
+            <p className="text-sm text-muted-foreground">
+              Counting workflows will surface here once the service layer is connected. Until then, use this space to brief
+              your team on procedures and track manual progress updates.
+            </p>
+          </section>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/pages/Putaway.tsx
+++ b/src/pages/Putaway.tsx
@@ -1,0 +1,49 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card';
+import { Separator } from '../components/ui/separator';
+import { useLanguage } from '../contexts/LanguageContext';
+
+export function Putaway() {
+  const { t } = useLanguage();
+
+  const focusAreas = [
+    'Assign optimal storage locations based on volume and turnover.',
+    'Confirm lot, batch, or serial data during placement.',
+    'Capture exceptions such as damaged goods or quantity discrepancies.',
+  ];
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>{t('putaway')}</CardTitle>
+          <CardDescription>
+            Direct received goods to their final storage locations and document exceptions immediately.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <section>
+            <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">Focus areas</h3>
+            <Separator className="my-3" />
+            <ul className="space-y-2 text-sm text-muted-foreground">
+              {focusAreas.map((item) => (
+                <li key={item} className="flex items-start gap-2">
+                  <span className="mt-1 h-1.5 w-1.5 rounded-full bg-primary" aria-hidden />
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <section>
+            <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">Coming soon</h3>
+            <Separator className="my-3" />
+            <p className="text-sm text-muted-foreground">
+              Task lists, RF device integration, and travel path optimization will be surfaced in this module as soon as the
+              data services are connected.
+            </p>
+          </section>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/pages/Reports.tsx
+++ b/src/pages/Reports.tsx
@@ -1,0 +1,49 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card';
+import { Separator } from '../components/ui/separator';
+import { useLanguage } from '../contexts/LanguageContext';
+
+export function Reports() {
+  const { t } = useLanguage();
+
+  const plannedReports = [
+    'Daily warehouse performance dashboard',
+    'Inventory valuation snapshot',
+    'Aging stock and near-expiry alerts',
+  ];
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>{t('reports')}</CardTitle>
+          <CardDescription>
+            Centralize operational and financial insights across your inventory network.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <section>
+            <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">Planned content</h3>
+            <Separator className="my-3" />
+            <ul className="space-y-2 text-sm text-muted-foreground">
+              {plannedReports.map((item) => (
+                <li key={item} className="flex items-start gap-2">
+                  <span className="mt-1 h-1.5 w-1.5 rounded-full bg-primary" aria-hidden />
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <section>
+            <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">Integration notes</h3>
+            <Separator className="my-3" />
+            <p className="text-sm text-muted-foreground">
+              Reporting widgets will connect to the analytics service once available. In the interim, use exported data from other
+              modules to build temporary dashboards.
+            </p>
+          </section>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add placeholder pages for warehouse operations, reports, and authentication links
- wire hash-based routing in App.tsx to new pages and centralize breadcrumb data

## Testing
- pnpm lint *(fails: prompts for initial ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68df6fbb8cd08325b6521806b7639dd3